### PR TITLE
Build base URL instead of using window.location

### DIFF
--- a/static/js/run_analysis.js
+++ b/static/js/run_analysis.js
@@ -1,4 +1,4 @@
-var apiUrl = window.location + "api/";
+var apiUrl = location.protocol + '//' + location.host + location.pathname + "api/";
 
 //check user input and process, generate result in tables
 $('.run-analysis.Button').click(function(){

--- a/static/js/update.js
+++ b/static/js/update.js
@@ -1,4 +1,4 @@
-var apiUrl = window.location + "api/";
+var apiUrl = location.protocol + '//' + location.host + location.pathname + "api/";
 
 //update interface with portfolios and risk factors
 function updateText() {


### PR DESCRIPTION
Using window.location to build the base URL will give funny
results when query args are passed in (in the case of tracking
metrics), since they are included. This means the following lines

  var apiUrl = window.location + "api/";

would evaluate to:

  apiURL = https://predictive-market-stress-testing.mybluemix.net/?foo=barapi/

Which led to several API calls hanging.

Build the base URL correctly with protocol, host and path instead

  apiURL = location.protocol + '//' + location.host + location.pathname